### PR TITLE
google maps: use current release version 3.31

### DIFF
--- a/web-app/public/index.html
+++ b/web-app/public/index.html
@@ -20,7 +20,7 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700" rel="stylesheet">
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.27&libraries=places,geometry&key=AIzaSyD0AC9TcY3xdmRsc_atlSHRreEbnEbxPEA"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.31&libraries=places,geometry&key=AIzaSyD0AC9TcY3xdmRsc_atlSHRreEbnEbxPEA"></script>
     <title>World Cleanup</title>
   </head>
   <body>

--- a/web-app/src/shared/constants.js
+++ b/web-app/src/shared/constants.js
@@ -1,5 +1,5 @@
 export const GOOGLE_MAPS_API_KEY = 'AIzaSyD0AC9TcY3xdmRsc_atlSHRreEbnEbxPEA';
-export const googleMapURL = `https://maps.googleapis.com/maps/api/js?v=3.27&libraries=places,geometry&key=${GOOGLE_MAPS_API_KEY}`;
+export const googleMapURL = `https://maps.googleapis.com/maps/api/js?v=3.31&libraries=places,geometry&key=${GOOGLE_MAPS_API_KEY}`;
 export const DEFAULT_ZOOM_LEVEL = 18;
 export const NO_PERMISSION_ZOOM_LEVEL = 9;
 export const ESTONIA_CENTER_COORDINATES = { lat: 58.5953, lng: 25.0136 };


### PR DESCRIPTION
fixes #185 (deprecation warning)

testing confirmed the local irrelevance of the upstream changes.