### PR TITLE
mobile-app: make use of translated trash types #156

### DIFF
--- a/mobile-app/src/screens/CreateMarker/CreateMarker.js
+++ b/mobile-app/src/screens/CreateMarker/CreateMarker.js
@@ -92,7 +92,8 @@ class CreateMarker extends Component {
       congratsShown: false,
       trashCompositionTypes: TRASH_COMPOSITION_TYPE_LIST.map(
         trashCompositionType => ({
-          ...trashCompositionType,
+          trashCompositionType.type,
+          props.t(trashCompositionType.label),
           selected: false,
         }),
       ),

--- a/mobile-app/src/screens/EditTrashpoint/EditTrashpoint.js
+++ b/mobile-app/src/screens/EditTrashpoint/EditTrashpoint.js
@@ -108,7 +108,8 @@ class EditTrashpoint extends Component {
       trashCompositionTypes: TRASH_COMPOSITION_TYPE_LIST.map(
         (trashCompositionType) => {
           return {
-            ...trashCompositionType,
+            trashCompositionType.type,
+            props.t(trashCompositionType.label),
             selected: marker.composition.indexOf(trashCompositionType.type) !== -1,
           };
         },

--- a/mobile-app/src/shared/constants.js
+++ b/mobile-app/src/shared/constants.js
@@ -62,15 +62,15 @@ export const TRASH_COMPOSITION_TYPES_HASH = {
 };
 
 export const TRASH_COMPOSITION_TYPE_LIST = [
-  { type: 'plastic', label: 'Plastic' },
-  { type: 'metal', label: 'Metal' },
-  { type: 'glass', label: 'Glass' },
-  { type: 'electronics', label: 'Electronics' },
-  { type: 'paper', label: 'Paper/Wood' },
-  { type: 'tyres', label: 'Tyres' },
-  { type: 'domestic waste', label: 'Domestic waste' },
-  { type: 'furniture', label: 'Furniture' },
-  { type: 'organic waste', label: 'Organic waste' },
+  { type: 'plastic', label: 'label_trash_type_plastic' },
+  { type: 'metal', label: 'label_trash_type_metal' },
+  { type: 'glass', label: 'label_trash_type_glass' },
+  { type: 'electronics', label: 'label_trash_type_electro' },
+  { type: 'paper', label: 'label_trash_type_paper' },
+  { type: 'tyres', label: 'label_trash_type_tyres' },
+  { type: 'domestic waste', label: 'label_trash_type_dom_waste' },
+  { type: 'furniture', label: 'label_trash_type_furniture' },
+  { type: 'organic waste', label: 'label_trash_type_org_waste' },
 ];
 
 export const AMOUNT_HASH = {


### PR DESCRIPTION
I can't build the app, so while trivial, this is untested.

Nothing else is using this TRASH_COMPOSITION_TYPE_LIST. web-app has it's own copy, but none of the web backend is translatable or not yet, so out of scope for this change.